### PR TITLE
fix: correct link text Step 2.6 to Step 2 in overview.md

### DIFF
--- a/help/app-builder/first-app/overview.md
+++ b/help/app-builder/first-app/overview.md
@@ -36,7 +36,7 @@ This tutorial has the following prerequisites:
 * Full access or trial access to App Builder has been granted
 * [The Adobe Developer App Builder application has been created](https://developer.adobe.com/app-builder/docs/get_started/app_builder_get_started/first-app){target="_blank"}
 * [The Adobe Developer App Builder project has been created](https://developer.adobe.com/console){target="_blank"}
-* [The Adobe Developer App Builder workspaces have been created - Step 2.6](https://developer.adobe.com/app-builder/docs/get_started/app_builder_get_started/first-app#2-creating-a-new-project-on-developer-console){target="_blank"}
+* [The Adobe Developer App Builder workspaces have been created - Step 2](https://developer.adobe.com/app-builder/docs/get_started/app_builder_get_started/first-app#2-creating-a-new-project-on-developer-console){target="_blank"}
 * [The AIO CLI commands to initialize the project and run have been executed](https://developer.adobe.com/runtime){target="_blank"}
 
 For more information on building your first App Builder application, you can view the following blog post to help with this initial setup and configuration [How App Builder helps drive business agility for your commerce platform](https://business.adobe.com/blog/how-to/how-app-builder-helps-you-implement-a-composable-commerce-strategy){target="_blank"}.


### PR DESCRIPTION
## Summary
Fixes #8 - incorrect link text in `help/app-builder/first-app/overview.md`.

The prerequisite list contains a link with text 'Step 2.6' but the referenced section is actually 'Step 2 - Creating a new project on Developer Console'. Changed 'Step 2.6' → 'Step 2'.

## Change
- `help/app-builder/first-app/overview.md` line 39: `Step 2.6` → `Step 2`
- 1 file, 1 line changed

## Rebase note
PR #9 had merge conflicts (dirty) due to structural changes in upstream. This is a clean rebase onto the latest `main`.

## Verification
- Diff: only the step number text changed
- GH007 compliant